### PR TITLE
Add completion files for bash and zsh

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -29,9 +29,9 @@ _mtracker() {
             ;;
         rate|r)
             if [[ $COMP_CWORD -eq 2 ]]; then
-                local unrated_movies IFS=$'\n'
-                unrated_movies=$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")
-                COMPREPLY=( $(compgen -W "$unrated_movies" -- "$cur") )
+                local movies IFS=$'\n'
+                movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
+                COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
             elif [[ $COMP_CWORD -eq 3 ]]; then
                 COMPREPLY=( $(compgen -W "0 1 2 3 4 5 6 7 8 9" -- "$cur") )
             fi

--- a/completions/bash
+++ b/completions/bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+_mtracker() {
+	local cur prev commands
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	commands="list ls add a remove rm rate r unrate u edit help"
+
+	if [[ $COMP_CWORD -eq 1 ]]; then
+		COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+		return 0
+	fi
+
+	case "${COMP_WORDS[1]}" in
+		add|a)
+			if [[ $COMP_CWORD -eq 2 ]]; then
+				local unrated_movies IFS=$'\n'
+				movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
+				COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
+			elif [[ $COMP_CWORD -eq 3 ]]; then
+				COMPREPLY=( $(compgen -W "--tag" -- "$cur") )
+			fi
+			;;
+		remove|rm)
+			local movies IFS=$'\n'
+			movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
+			COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
+			;;
+		rate|r)
+			if [[ $COMP_CWORD -eq 2 ]]; then
+				local unrated_movies IFS=$'\n'
+				unrated_movies=$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")
+				COMPREPLY=( $(compgen -W "$unrated_movies" -- "$cur") )
+			elif [[ $COMP_CWORD -eq 3 ]]; then
+				COMPREPLY=( $(compgen -W "0 1 2 3 4 5 6 7 8 9" -- "$cur") )
+			fi
+			;;
+		unrate|u)
+			local rated_movies IFS=$'\n'
+			rated_movies=$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")
+			COMPREPLY=( $(compgen -W "$rated_movies" -- "$cur") )
+			;;
+		list|ls)
+			COMPREPLY=( $(compgen -W "--tag --year" -- "$cur") )
+			;;
+	esac
+
+	return 0
+}
+
+complete -F _mtracker mtracker

--- a/completions/bash
+++ b/completions/bash
@@ -38,7 +38,7 @@ _mtracker() {
             ;;
         unrate|u)
             local rated_movies IFS=$'\n'
-            rated_movies=$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")
+            rated_movies=$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s(WL:\s)?//")
             COMPREPLY=( $(compgen -W "$rated_movies" -- "$cur") )
             ;;
         list|ls)

--- a/completions/bash
+++ b/completions/bash
@@ -1,52 +1,52 @@
 #!/bin/bash
 
 _mtracker() {
-	local cur prev commands
-	COMPREPLY=()
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	commands="list ls add a remove rm rate r unrate u edit help"
+    local cur prev commands
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    commands="list ls add a remove rm rate r unrate u edit help"
 
-	if [[ $COMP_CWORD -eq 1 ]]; then
-		COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
-		return 0
-	fi
+    if [[ $COMP_CWORD -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+        return 0
+    fi
 
-	case "${COMP_WORDS[1]}" in
-		add|a)
-			if [[ $COMP_CWORD -eq 2 ]]; then
-				local unrated_movies IFS=$'\n'
-				movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
-				COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
-			elif [[ $COMP_CWORD -eq 3 ]]; then
-				COMPREPLY=( $(compgen -W "--tag" -- "$cur") )
-			fi
-			;;
-		remove|rm)
-			local movies IFS=$'\n'
-			movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
-			COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
-			;;
-		rate|r)
-			if [[ $COMP_CWORD -eq 2 ]]; then
-				local unrated_movies IFS=$'\n'
-				unrated_movies=$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")
-				COMPREPLY=( $(compgen -W "$unrated_movies" -- "$cur") )
-			elif [[ $COMP_CWORD -eq 3 ]]; then
-				COMPREPLY=( $(compgen -W "0 1 2 3 4 5 6 7 8 9" -- "$cur") )
-			fi
-			;;
-		unrate|u)
-			local rated_movies IFS=$'\n'
-			rated_movies=$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")
-			COMPREPLY=( $(compgen -W "$rated_movies" -- "$cur") )
-			;;
-		list|ls)
-			COMPREPLY=( $(compgen -W "--tag --year" -- "$cur") )
-			;;
-	esac
+    case "${COMP_WORDS[1]}" in
+        add|a)
+            if [[ $COMP_CWORD -eq 2 ]]; then
+                local unrated_movies IFS=$'\n'
+                movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
+                COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
+            elif [[ $COMP_CWORD -eq 3 ]]; then
+                COMPREPLY=( $(compgen -W "--tag" -- "$cur") )
+            fi
+            ;;
+        remove|rm)
+            local movies IFS=$'\n'
+            movies=$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")
+            COMPREPLY=( $(compgen -W "$movies" -- "$cur") )
+            ;;
+        rate|r)
+            if [[ $COMP_CWORD -eq 2 ]]; then
+                local unrated_movies IFS=$'\n'
+                unrated_movies=$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")
+                COMPREPLY=( $(compgen -W "$unrated_movies" -- "$cur") )
+            elif [[ $COMP_CWORD -eq 3 ]]; then
+                COMPREPLY=( $(compgen -W "0 1 2 3 4 5 6 7 8 9" -- "$cur") )
+            fi
+            ;;
+        unrate|u)
+            local rated_movies IFS=$'\n'
+            rated_movies=$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")
+            COMPREPLY=( $(compgen -W "$rated_movies" -- "$cur") )
+            ;;
+        list|ls)
+            COMPREPLY=( $(compgen -W "--tag --year" -- "$cur") )
+            ;;
+    esac
 
-	return 0
+    return 0
 }
 
 complete -F _mtracker mtracker

--- a/completions/zsh
+++ b/completions/zsh
@@ -1,0 +1,65 @@
+#compdef mtracker
+
+_mtracker() {
+	local -a commands
+	local curcontext="$curcontext" state line
+
+	commands=(
+		'list:List tracked movies'
+		'ls:List tracked movies'
+		'add:Track a movie'
+		'a:Track a movie'
+		'remove:Untrack a movie'
+		'rm:Untrack a movie'
+		'rate:Rate a tracked movie'
+		'r:Rate a tracked movie'
+		'unrate:Unrate a tracked movie'
+		'u:Unrate a tracked movie'
+		'edit:Edit item or whole database'
+		'help:Print the usage help'
+	)
+
+	_arguments -C \
+		'1:command:->command' \
+		'*::arg:->args'
+
+	case $state in
+		command)
+			_describe 'command' commands
+			;;
+		args)
+			case $line[1] in
+				(add|a)
+					local -a movies
+					movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
+					_arguments \
+						'1:movie name:_values "movie" "${movies[@]}"' \
+						'--tag[add tags to a movie, either tracked or untracked]'
+					;;
+				(remove|rm)
+					local -a movies
+					movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
+					_arguments '1:movie ID:(${movies})'
+					;;
+				(rate|r)
+					local -a unrated_movies
+					unrated_movies=("${(@f)$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")}")
+
+					_arguments \
+						'1:movie ID:(${unrated_movies})' \
+						'2:rating (0-9):(0 1 2 3 4 5 6 7 8 9)'
+					;;
+				(unrate|u)
+					local -a rated_movies
+					rated_movies=("${(@f)$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")}")
+					_arguments '1:movie ID:(${rated_movies})'
+					;;
+				(list|ls)
+					_arguments '--tag[show only movies with the specified tags]' '--year[show movies matching the year query]'
+					;;
+			esac
+			;;
+	esac
+}
+
+compdef _mtracker mtracker

--- a/completions/zsh
+++ b/completions/zsh
@@ -51,7 +51,7 @@ _mtracker() {
                     ;;
                 (unrate|u)
                     local -a rated_movies
-                    rated_movies=("${(@f)$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")}")
+                    rated_movies=("${(@f)$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s(WL:\s)?//")}")
                     _arguments '1:movie ID:(${rated_movies})'
                     ;;
                 (list|ls)

--- a/completions/zsh
+++ b/completions/zsh
@@ -42,11 +42,11 @@ _mtracker() {
                     _arguments '1:movie ID:(${movies})'
                     ;;
                 (rate|r)
-                    local -a unrated_movies
-                    unrated_movies=("${(@f)$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")}")
+                    local -a movies
+                    movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
 
                     _arguments \
-                        '1:movie ID:(${unrated_movies})' \
+                        '1:movie ID:(${movies})' \
                         '2:rating (0-9):(0 1 2 3 4 5 6 7 8 9)'
                     ;;
                 (unrate|u)

--- a/completions/zsh
+++ b/completions/zsh
@@ -1,65 +1,65 @@
 #compdef mtracker
 
 _mtracker() {
-	local -a commands
-	local curcontext="$curcontext" state line
+    local -a commands
+    local curcontext="$curcontext" state line
 
-	commands=(
-		'list:List tracked movies'
-		'ls:List tracked movies'
-		'add:Track a movie'
-		'a:Track a movie'
-		'remove:Untrack a movie'
-		'rm:Untrack a movie'
-		'rate:Rate a tracked movie'
-		'r:Rate a tracked movie'
-		'unrate:Unrate a tracked movie'
-		'u:Unrate a tracked movie'
-		'edit:Edit item or whole database'
-		'help:Print the usage help'
-	)
+    commands=(
+        'list:List tracked movies'
+        'ls:List tracked movies'
+        'add:Track a movie'
+        'a:Track a movie'
+        'remove:Untrack a movie'
+        'rm:Untrack a movie'
+        'rate:Rate a tracked movie'
+        'r:Rate a tracked movie'
+        'unrate:Unrate a tracked movie'
+        'u:Unrate a tracked movie'
+        'edit:Edit item or whole database'
+        'help:Print the usage help'
+    )
 
-	_arguments -C \
-		'1:command:->command' \
-		'*::arg:->args'
+    _arguments -C \
+        '1:command:->command' \
+        '*::arg:->args'
 
-	case $state in
-		command)
-			_describe 'command' commands
-			;;
-		args)
-			case $line[1] in
-				(add|a)
-					local -a movies
-					movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
-					_arguments \
-						'1:movie name:_values "movie" "${movies[@]}"' \
-						'--tag[add tags to a movie, either tracked or untracked]'
-					;;
-				(remove|rm)
-					local -a movies
-					movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
-					_arguments '1:movie ID:(${movies})'
-					;;
-				(rate|r)
-					local -a unrated_movies
-					unrated_movies=("${(@f)$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")}")
+    case $state in
+        command)
+            _describe 'command' commands
+            ;;
+        args)
+            case $line[1] in
+                (add|a)
+                    local -a movies
+                    movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
+                    _arguments \
+                        '1:movie name:_values "movie" "${movies[@]}"' \
+                        '--tag[add tags to a movie, either tracked or untracked]'
+                    ;;
+                (remove|rm)
+                    local -a movies
+                    movies=("${(@f)$(mtracker ls | sed -E "s/^\S+\s(WL:\s)?//")}")
+                    _arguments '1:movie ID:(${movies})'
+                    ;;
+                (rate|r)
+                    local -a unrated_movies
+                    unrated_movies=("${(@f)$(mtracker ls | grep -E "^\?+\s" | sed -E "s/^\?+\s//" | grep -Ev "^WL")}")
 
-					_arguments \
-						'1:movie ID:(${unrated_movies})' \
-						'2:rating (0-9):(0 1 2 3 4 5 6 7 8 9)'
-					;;
-				(unrate|u)
-					local -a rated_movies
-					rated_movies=("${(@f)$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")}")
-					_arguments '1:movie ID:(${rated_movies})'
-					;;
-				(list|ls)
-					_arguments '--tag[show only movies with the specified tags]' '--year[show movies matching the year query]'
-					;;
-			esac
-			;;
-	esac
+                    _arguments \
+                        '1:movie ID:(${unrated_movies})' \
+                        '2:rating (0-9):(0 1 2 3 4 5 6 7 8 9)'
+                    ;;
+                (unrate|u)
+                    local -a rated_movies
+                    rated_movies=("${(@f)$(mtracker ls | grep -Ev "^\?" | sed -E "s/^\S+\s//")}")
+                    _arguments '1:movie ID:(${rated_movies})'
+                    ;;
+                (list|ls)
+                    _arguments '--tag[show only movies with the specified tags]' '--year[show movies matching the year query]'
+                    ;;
+            esac
+            ;;
+    esac
 }
 
 compdef _mtracker mtracker


### PR DESCRIPTION
No more typing full movie names to rate or manage your collection! This PR introduces intelligent autocompletion for `mtracker` commands, providing suggestions based on context. Here's a breakdown of the new autocomplete behaviors:

- **add | a**
  - Suggests movie titles from the database
  - Once a movie is specified, suggests `--tag`
- **remove | rm**
  - Suggests movie titles from the database
- **rate | r**
  - Suggests **unrated** movie titles from the database
  - After selecting a movie, suggests ratings from 0 to 9
- **unrate | u**
  - Suggests **rated** movie titles from the database
- **list | ls**
  - Suggests `--tag` and `--year`

## Testing

Source the appropriate shell completion script (`completions/zsh` or `completions/bash`) and use tab completion on `mtracker` subcommands to verify suggestions are working as described.

## Limitations

Bash lacks built-in support for displaying detailed argument descriptions and for suggesting strings that contain spaces. As a result, Bash completion is limited to simpler cases without complex suggestions.