### PR TITLE
Refactor `Repo` to reduce mutability requirements

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -16,14 +16,14 @@ pub fn command() -> Command {
         .arg(args::note())
 }
 
-pub fn handle(repo: &mut repo::Repo, matches: &ArgMatches) -> Result<()> {
+pub fn handle(matches: &ArgMatches) -> Result<()> {
     // Get args
     let handle = arg_util::handle_from_matches(matches)?.unwrap();
     let tags = arg_util::tags_from_matches(matches);
     let note = arg_util::note_from_matches(matches)?;
 
     // Init repo
-    repo.read()?;
+    let mut repo = repo::Repo::default();
 
     // Report error when just adding an existing item
     let media = repo.get(&handle);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ mod list;
 mod media;
 mod rate;
 mod remove;
-mod unrate;
 mod tags;
+mod unrate;
 
 #[allow(clippy::missing_errors_doc)]
 #[allow(clippy::missing_panics_doc)]
@@ -32,22 +32,15 @@ pub fn run() -> Result<()> {
         .subcommand(tags::command())
         .get_matches();
 
-    // Get database path
-    let mut db_file_path = dirs::data_dir().expect("failed to get user data directory");
-    db_file_path.push(format!("{}/db.txt", crate_name!()));
-
-    // Init media repo
-    let mut repo = media::repo::Repo::new(&db_file_path);
-
     // Run command
     match matches.subcommand() {
-        Some(("ls", matches)) => list::handle(&mut repo, matches),
-        Some(("add", matches)) => add::handle(&mut repo, matches),
-        Some(("rm", matches)) => remove::handle(&mut repo, matches),
-        Some(("rate", matches)) => rate::handle(&mut repo, matches),
-        Some(("unrate", matches)) => unrate::handle(&mut repo, matches),
-        Some(("edit", matches)) => edit::handle(&mut repo, matches),
-        Some(("tags", matches)) => tags::handle(&mut repo, matches),
+        Some(("ls", matches)) => list::handle(matches),
+        Some(("add", matches)) => add::handle(matches),
+        Some(("rm", matches)) => remove::handle(matches),
+        Some(("rate", matches)) => rate::handle(matches),
+        Some(("unrate", matches)) => unrate::handle(matches),
+        Some(("edit", matches)) => edit::handle(matches),
+        Some(("tags", matches)) => tags::handle(matches),
         _ => unreachable!(),
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -15,12 +15,12 @@ pub fn command() -> Command {
         .arg(args::tags_bool().help("Whether to display tags"))
 }
 
-pub fn handle(repo: &mut media::repo::Repo, matches: &ArgMatches) -> Result<()> {
+pub fn handle(matches: &ArgMatches) -> Result<()> {
     // Get args
     let terms = arg_util::terms_from_matches(matches);
 
     // Init repo
-    repo.read()?;
+    let repo = media::repo::Repo::default();
 
     let mut items = repo.get_all();
 

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::convert::Into;
 
+pub mod config;
 pub mod format;
 pub mod handle;
 pub mod parser;

--- a/src/media/config.rs
+++ b/src/media/config.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use clap::crate_name;
+
+pub struct Config {
+    pub path: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let mut db_file_path = dirs::data_dir().expect("failed to get user data directory");
+        db_file_path.push(format!("{}/db.txt", crate_name!()));
+        Self { path: db_file_path }
+    }
+}

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -20,13 +20,13 @@ pub fn command() -> Command {
         .arg(args::year())
 }
 
-pub fn handle(repo: &mut repo::Repo, matches: &ArgMatches) -> Result<()> {
+pub fn handle(matches: &ArgMatches) -> Result<()> {
     // Get args
     let handle = arg_util::handle_from_matches(matches)?.unwrap();
     let rating = matches.get_one::<u8>("RATING");
 
     // Init repo
-    repo.read()?;
+    let mut repo = repo::Repo::default();
 
     let media = repo.get_or_create(&handle);
 

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -15,13 +15,13 @@ pub fn command() -> Command {
         .arg(args::tag().help("Tag(s) to remove, comma-separated"))
 }
 
-pub fn handle(repo: &mut repo::Repo, matches: &ArgMatches) -> Result<()> {
+pub fn handle(matches: &ArgMatches) -> Result<()> {
     // Get args
     let handle = arg_util::handle_from_matches(matches)?.unwrap();
     let tags = arg_util::tags_from_matches(matches);
 
     // Init repo
-    repo.read()?;
+    let mut repo = repo::Repo::default();
 
     // Remove item
     if tags.is_empty() {

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -9,8 +9,8 @@ pub fn command() -> Command {
         .arg_required_else_help(false)
 }
 
-pub fn handle(repo: &mut media::repo::Repo, _matches: &ArgMatches) -> Result<()> {
-    repo.read()?;
+pub fn handle(_matches: &ArgMatches) -> Result<()> {
+    let repo = media::repo::Repo::default();
 
     // Get list of tags (including duplicates)
     let tags = repo.get_all()

--- a/src/unrate.rs
+++ b/src/unrate.rs
@@ -14,12 +14,12 @@ pub fn command() -> Command {
         .arg(args::year())
 }
 
-pub fn handle(repo: &mut repo::Repo, matches: &ArgMatches) -> Result<()> {
+pub fn handle(matches: &ArgMatches) -> Result<()> {
     // Get args
     let handle = arg_util::handle_from_matches(matches)?.unwrap();
 
     // Init repo
-    repo.read()?;
+    let mut repo = repo::Repo::default();
 
     let media = repo.get_or_create(&handle);
 


### PR DESCRIPTION
The first thing that caught my eye were runtime assertions, I've started refactoring by adding a `PhantomData<State>` field to the `Repo` struct (then `Repo<State>`). Then I've renamed the `Repo::read` method to `Repo::init` to make it more explicit and had it return a `Repo<Initialized>`, basically this served as a compile-time constraint to enforce initialization before being able to call methods such as `Repo<Initialized>::get()`.

Afterwards I noticed two things:
1 -  this was too convoluted;
2 - not every subcommand needed an `&mut Repo`.

This meant that decoupling could've allowed for better separation of concerns. So I've built a new `Config` class and added two `Default` trait impl for `Repo` and `Config`. I've then moved initialization to the private `Repo::new` method, so there should be no way to create an uninitialized instance of `Repo`.

One more interesting change is that since `Default::default` cannot return an `Error` we directly panic during `Repo` creation. This should be okay since propagation of the error would've resulted in a panic anyway.

As a sidenote: the previous implementation of `Repo::read` (now `Repo::init`) performed convoluted checks (is the DB file empty? Can the DB file be opened?), all of them resulted in a `Repo` with an empty `items` vector. Since this is the default behaviour when the read DB content is an empty string (without all the checks), I'm simply doing `fs::read_to_string(&self.config.path).unwrap_or_default()`. I've added a test to make sure that this worked.

### Why `init` instead of `read`?

Previously we had something like:

```rust
pub fn handle(repo: &mut repo::Repo) -> Result<()> {
    repo.read()?;
}
```

And this got me thinking:
- why does `read` need a mutable reference to self if I'm only reading from the repo?
- why does this `read` return a `Result<()>` instead of what has been read?

After reading the code through it became clear that it is actually initializing the `items` field of the `Repo`, so it is reading from memory to `repo`, not from `repo` to the method consumer.


### Things I'm not convinced about

- should I revert to keep declaring the `repo` to be passed to handlers in `lib.rs`?  (Sometimes we need it to be mutable sometimes we don't)
- should `config.rs` be kept outside of `src/media`?

Let me know if you notice anything else!